### PR TITLE
Removed unnecessary dialogue boxes and added auto config loading/saving

### DIFF
--- a/tarmac/Tarmac64 Library/CourseCompiler.Designer.cs
+++ b/tarmac/Tarmac64 Library/CourseCompiler.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Tarmac64_Library
+namespace Tarmac64_Library
 {
     partial class CourseCompiler
     {
@@ -61,7 +61,7 @@
             this.chkWireframe = new System.Windows.Forms.CheckBox();
             this.chkHover = new System.Windows.Forms.CheckBox();
             this.chkSection = new System.Windows.Forms.CheckBox();
-            this.button1 = new System.Windows.Forms.Button();
+            this.exportBtn = new System.Windows.Forms.Button();
             this.importBtn = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.label9 = new System.Windows.Forms.Label();
@@ -96,8 +96,6 @@
             this.textBox6 = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBox3 = new System.Windows.Forms.ComboBox();
-            this.ImportData = new System.Windows.Forms.Button();
-            this.SaveBtn = new System.Windows.Forms.Button();
             this.label51 = new System.Windows.Forms.Label();
             this.groupBox7 = new System.Windows.Forms.GroupBox();
             this.label50 = new System.Windows.Forms.Label();
@@ -546,7 +544,7 @@
             this.SectionViews.Controls.Add(this.chkWireframe);
             this.SectionViews.Controls.Add(this.chkHover);
             this.SectionViews.Controls.Add(this.chkSection);
-            this.SectionViews.Controls.Add(this.button1);
+            this.SectionViews.Controls.Add(this.exportBtn);
             this.SectionViews.Controls.Add(this.importBtn);
             this.SectionViews.Controls.Add(this.groupBox1);
             this.SectionViews.Controls.Add(this.sectionBox);
@@ -623,16 +621,16 @@
             this.chkSection.UseVisualStyleBackColor = true;
             this.chkSection.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
             // 
-            // button1
+            // exportBtn
             // 
-            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.button1.Location = new System.Drawing.Point(70, 469);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(61, 23);
-            this.button1.TabIndex = 4;
-            this.button1.Text = "Export";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.Button1_Click_1);
+            this.exportBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.exportBtn.Location = new System.Drawing.Point(70, 469);
+            this.exportBtn.Name = "button1";
+            this.exportBtn.Size = new System.Drawing.Size(61, 23);
+            this.exportBtn.TabIndex = 4;
+            this.exportBtn.Text = "Export";
+            this.exportBtn.UseVisualStyleBackColor = true;
+            this.exportBtn.Click += new System.EventHandler(this.ExportBtn_Click);
             // 
             // importBtn
             // 
@@ -643,8 +641,7 @@
             this.importBtn.TabIndex = 3;
             this.importBtn.Text = "Import";
             this.importBtn.UseVisualStyleBackColor = true;
-            this.importBtn.Click += new System.EventHandler(this.ImportBtn_Click);
-            // 
+            this.importBtn.Click += new System.EventHandler(this.ImportBtn_Click);// 
             // groupBox1
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
@@ -999,8 +996,6 @@
             this.CourseInfo.Controls.Add(this.textBox6);
             this.CourseInfo.Controls.Add(this.label1);
             this.CourseInfo.Controls.Add(this.comboBox3);
-            this.CourseInfo.Controls.Add(this.ImportData);
-            this.CourseInfo.Controls.Add(this.SaveBtn);
             this.CourseInfo.Controls.Add(this.label51);
             this.CourseInfo.Controls.Add(this.groupBox7);
             this.CourseInfo.Controls.Add(this.waterBox);
@@ -1081,30 +1076,6 @@
             this.comboBox3.Name = "comboBox3";
             this.comboBox3.Size = new System.Drawing.Size(89, 21);
             this.comboBox3.TabIndex = 183;
-            // 
-            // ImportData
-            // 
-            this.ImportData.AutoSize = true;
-            this.ImportData.Location = new System.Drawing.Point(5, 24);
-            this.ImportData.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.ImportData.Name = "ImportData";
-            this.ImportData.Size = new System.Drawing.Size(65, 23);
-            this.ImportData.TabIndex = 1;
-            this.ImportData.Text = "Import";
-            this.ImportData.UseVisualStyleBackColor = true;
-            this.ImportData.Click += new System.EventHandler(this.ImportCourseInfo);
-            // 
-            // SaveBtn
-            // 
-            this.SaveBtn.AutoSize = true;
-            this.SaveBtn.Location = new System.Drawing.Point(76, 24);
-            this.SaveBtn.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.SaveBtn.Name = "SaveBtn";
-            this.SaveBtn.Size = new System.Drawing.Size(65, 23);
-            this.SaveBtn.TabIndex = 2;
-            this.SaveBtn.Text = "Export";
-            this.SaveBtn.UseVisualStyleBackColor = true;
-            this.SaveBtn.Click += new System.EventHandler(this.SaveBtn_Click);
             // 
             // label51
             // 
@@ -2289,7 +2260,7 @@
         private System.Windows.Forms.CheckBox chkWireframe;
         private System.Windows.Forms.CheckBox chkHover;
         private System.Windows.Forms.CheckBox chkSection;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button exportBtn;
         private System.Windows.Forms.Button importBtn;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.Label label9;
@@ -2421,8 +2392,6 @@
         private System.Windows.Forms.ComboBox textureModeTBox;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.TextBox heightBox;
-        private System.Windows.Forms.Button ImportData;
-        private System.Windows.Forms.Button SaveBtn;
         private System.Windows.Forms.PictureBox pictureBox2;
         private System.Windows.Forms.Label label57;
         private System.Windows.Forms.TextBox textBox6;

--- a/tarmac/Tarmac64 Library/CourseCompiler.cs
+++ b/tarmac/Tarmac64 Library/CourseCompiler.cs
@@ -2813,7 +2813,7 @@ namespace Tarmac64_Library
 
             if (!File.Exists(okSettings.CurrentDirectory + "\\CONFIG.OK64"))
             {
-                File.Create(okSettings.CurrentDirectory + "\\CONFIG.OK64");
+                File.Create(okSettings.CurrentDirectory + "\\CONFIG.OK64").Close();
             }
             if (File.Exists(okSettings.CurrentDirectory + "\\CONFIG.OK64"))
             {

--- a/tarmac/Tarmac64 Library/CourseCompiler.cs
+++ b/tarmac/Tarmac64 Library/CourseCompiler.cs
@@ -2871,7 +2871,7 @@ namespace Tarmac64_Library
             }
             else
             {
-                MessageBox.Show("CONFIG.OK64 Error! Continuing without loading previous user input.");
+                MessageBox.Show("CONFIG.OK64 does not exist or is corrupted.\nFile will be created during compile to save user input.");
             }
         }
 

--- a/tarmac/Tarmac64 Library/CourseCompiler.cs
+++ b/tarmac/Tarmac64 Library/CourseCompiler.cs
@@ -23,7 +23,6 @@ using System.Windows.Input;
 using System.Drawing.Imaging;
 using Cereal64.Microcodes.F3DEX.DataElements;
 using Microsoft.WindowsAPICodePack.Dialogs;
-using Microsoft.Win32;
 
 namespace Tarmac64_Library
 {

--- a/tarmac/Tarmac64 Library/ObjectCompiler.cs
+++ b/tarmac/Tarmac64 Library/ObjectCompiler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Forms;
@@ -23,17 +23,19 @@ using System.Windows.Input;
 using System.Drawing.Imaging;
 using Cereal64.Microcodes.F3DEX.DataElements;
 using Microsoft.WindowsAPICodePack.Dialogs;
+using Microsoft.Win32;
 
 namespace Tarmac64_Library
 {
 
 
-    public partial class ObjectCompiler: Form
+    public partial class CourseCompiler : Form
     {
 
         TM64 Tarmac = new TM64();
         TM64_Course TarmacCourse = new TM64_Course();
         TM64_GL TarmacGL = new TM64_GL();
+        CommonOpenFileDialog fileOpen = new CommonOpenFileDialog();
 
         TM64.OK64Settings okSettings = new TM64.OK64Settings();
 
@@ -43,10 +45,10 @@ namespace Tarmac64_Library
         int sectionCount = 0;
         public int programFormat;
         int levelFormat = 0;
-        
 
 
-        public ObjectCompiler()
+
+        public CourseCompiler()
         {
             InitializeComponent();
         }
@@ -66,11 +68,6 @@ namespace Tarmac64_Library
             skyData.TopColor.B = 0;
             skyData.TopColor.A = 0;
 
-            skyData.MidColor = new TM64_Geometry.OK64Color();
-            skyData.MidColor.R = 0;
-            skyData.MidColor.G = 0;
-            skyData.MidColor.B = 0;
-            skyData.MidColor.A = 0;
 
             skyData.BotColor = new TM64_Geometry.OK64Color();
             skyData.BotColor.R = 0;
@@ -80,6 +77,7 @@ namespace Tarmac64_Library
         }
         private void FormLoad(object sender, EventArgs e)
         {
+
             CreateGeometry();
             CreateColors();
             okSettings = Tarmac.LoadSettings();
@@ -88,18 +86,45 @@ namespace Tarmac64_Library
             gl = openGLControl.OpenGL;
             if (System.Diagnostics.Process.GetCurrentProcess().ProcessName == "Tarmac64 Designer")
             {
-                about_button.Visible = true;
-            }
-            else
-            {
-                about_button.Visible = false;
+                tabControl1.TabPages.Remove(tabControl1.TabPages[4]);
             }
             courseBox.SelectedIndex = 0;
             cupBox.SelectedIndex = 0;
             setBox.SelectedIndex = 0;
 
+            SkyRM.Text = "216";
+            SkyGM.Text = "232";
+            SkyBM.Text = "248";
+
+            mapXBox.Text = "260";
+            mapYBox.Text = "170";
+            startXBox.Text = "6";
+            startYBox.Text = "28";
+            MapRBox.Text = "255";
+            MapGBox.Text = "255";
+            MapBBox.Text = "255";
+            MapScaleBox.Text = "1.55";
+
+            SkyRT.Text = "128";
+            SkyGT.Text = "184";
+            SkyBT.Text = "248";
             ColorUpdate();
 
+            for (int songIndex = 0; songIndex < songNames.Length; songIndex++)
+            {
+                songBox.Items.Add(songNames[songIndex]);
+            }
+            songBox.SelectedIndex = 3;
+
+            sp1Box.Text = "2";
+            sp2Box.Text = "2";
+            sp3Box.Text = "2";
+            sp4Box.Text = "2";
+
+            EchoStartBox.Text = "411";
+            EchoStopBox.Text = "440";
+
+            waterBox.Text = "-80";
         }
 
         Stopwatch clockTime = new Stopwatch();
@@ -159,7 +184,7 @@ namespace Tarmac64_Library
         List<TM64_Geometry.OK64F3DObject> masterList = new List<TM64_Geometry.OK64F3DObject>();
 
         TM64_Geometry.OK64F3DObject[] surfaceObjects = new TM64_Geometry.OK64F3DObject[0];
-    
+
 
         TM64_Geometry.OK64Texture[] textureArray = new TM64_Geometry.OK64Texture[0];
 
@@ -176,12 +201,7 @@ namespace Tarmac64_Library
         TM64_GL.TMCamera localCamera = new TM64_GL.TMCamera();
         OpenGL gl = new OpenGL();
 
-
-
-        OpenFileDialog fileOpen = new OpenFileDialog();
-        SaveFileDialog fileSave = new SaveFileDialog();
-        FolderBrowserDialog folderOpen = new FolderBrowserDialog();
-        
+    
 
 
 
@@ -617,6 +637,109 @@ namespace Tarmac64_Library
             System.Drawing.Color buttonColor = System.Drawing.Color.FromArgb(0,0,0);
             int[] colorInt = new int[3];
 
+            colorInt[0] = 0;
+            int.TryParse(SkyRT.Text, out colorInt[0]);
+            colorInt[1] = 0;
+            int.TryParse(SkyGT.Text, out colorInt[1]);
+            colorInt[2] = 0;
+            int.TryParse(SkyBT.Text, out colorInt[2]);
+
+            if (colorInt[0] < 256 & colorInt[0] > -1 & colorInt[1] < 256 & colorInt[1] > -1 & colorInt[2] < 256 & colorInt[2] > -1)
+            {
+                buttonColor = System.Drawing.Color.FromArgb(colorInt[0], colorInt[1], colorInt[2]);
+            }
+            else
+            {
+                buttonColor = System.Drawing.Color.FromArgb(0,0,0);
+            }
+            ColorPickT.BackColor = buttonColor;
+
+            colorInt[0] = 0;
+            int.TryParse(SkyRM.Text, out colorInt[0]);
+            colorInt[1] = 0;
+            int.TryParse(SkyGM.Text, out colorInt[1]);
+            colorInt[2] = 0;
+            int.TryParse(SkyBM.Text, out colorInt[2]);
+            if (colorInt[0] < 256 & colorInt[0] > -1 & colorInt[1] < 256 & colorInt[1] > -1 & colorInt[2] < 256 & colorInt[2] > -1)
+            {
+                buttonColor = System.Drawing.Color.FromArgb(colorInt[0], colorInt[1], colorInt[2]);
+            }
+            else
+            {
+                buttonColor = System.Drawing.Color.FromArgb(0, 0, 0);
+            }
+            ColorPickMT.BackColor = buttonColor;
+
+
+            colorInt[0] = 0;
+            int.TryParse(SkyRB.Text, out colorInt[0]);
+            colorInt[1] = 0;
+            int.TryParse(SkyGB.Text, out colorInt[1]);
+            colorInt[2] = 0;
+            int.TryParse(SkyBB.Text, out colorInt[2]);
+            if (colorInt[0] < 256 & colorInt[0] > -1 & colorInt[1] < 256 & colorInt[1] > -1 & colorInt[2] < 256 & colorInt[2] > -1)
+            {
+                buttonColor = System.Drawing.Color.FromArgb(colorInt[0], colorInt[1], colorInt[2]);
+            }
+            else
+            {
+                buttonColor = System.Drawing.Color.FromArgb(0, 0, 0);
+            }
+            ColorPickB.BackColor = buttonColor;
+
+            colorInt[0] = 0;
+            int.TryParse(MapRBox.Text, out colorInt[0]);
+            colorInt[1] = 0;
+            int.TryParse(MapGBox.Text, out colorInt[1]);
+            colorInt[2] = 0;
+            int.TryParse(MapBBox.Text, out colorInt[2]);
+            if (colorInt[0] < 256 & colorInt[0] > -1 & colorInt[1] < 256 & colorInt[1] > -1 & colorInt[2] < 256 & colorInt[2] > -1) 
+            {
+                buttonColor = System.Drawing.Color.FromArgb(colorInt[0], colorInt[1], colorInt[2]);
+            }
+            else
+            {
+                buttonColor = System.Drawing.Color.FromArgb(0, 0, 0);
+            }
+            ColorPickMap.BackColor = buttonColor;
+
+
+
+
+
+            byte colorValue = 0;
+            skyData.TopColor = new TM64_Geometry.OK64Color();
+            Byte.TryParse(SkyRT.Text, out colorValue);
+            skyData.TopColor.R = colorValue;
+            Byte.TryParse(SkyGT.Text, out colorValue);
+            skyData.TopColor.G = colorValue;
+            Byte.TryParse(SkyBT.Text, out colorValue);
+            skyData.TopColor.B = colorValue;
+
+            skyData.MidColor = new TM64_Geometry.OK64Color();
+            Byte.TryParse(SkyRM.Text, out colorValue);
+            skyData.MidColor.R = colorValue;
+            Byte.TryParse(SkyGM.Text, out colorValue);
+            skyData.MidColor.G = colorValue;
+            Byte.TryParse(SkyBM.Text, out colorValue);
+            skyData.MidColor.B = colorValue;
+
+            skyData.MidColor = new TM64_Geometry.OK64Color();
+            Byte.TryParse(SkyRB.Text, out colorValue);
+            skyData.MidColor.R = colorValue;
+            Byte.TryParse(SkyGB.Text, out colorValue);
+            skyData.MidColor.G = colorValue;
+            Byte.TryParse(SkyBB.Text, out colorValue);
+            skyData.MidColor.B = colorValue;
+
+
+            mapData.MapColor = new TM64_Geometry.OK64Color();
+            Byte.TryParse(MapRBox.Text, out colorValue);
+            mapData.MapColor.R = colorValue;
+            Byte.TryParse(MapGBox.Text, out colorValue);
+            mapData.MapColor.G = colorValue;
+            Byte.TryParse(MapBBox.Text, out colorValue);
+            mapData.MapColor.B = colorValue;
 
         }
 
@@ -627,17 +750,301 @@ namespace Tarmac64_Library
         private void CompileModel()
         {
 
-            
+            int cID = (cupBox.SelectedIndex * 4) + courseBox.SelectedIndex;
+            int setID = setBox.SelectedIndex;
+
+            CommonOpenFileDialog dialog = new CommonOpenFileDialog();
+
+                string outputDirectory = okSettings.CurrentDirectory + "\\out";
+                if (!Directory.Exists(outputDirectory))
+                {
+                    Directory.CreateDirectory(outputDirectory);
+                }
+  
+                if (File.Exists(okSettings.AppDirectory+"\\overkart.z64"))
+                {
+                
+                    List<byte[]> Segments = new List<byte[]>();
+                    byte[] rom = File.ReadAllBytes(okSettings.AppDirectory + "\\overkart.z64");
+
+
+                    byte[] segment4 = new byte[0];
+                    byte[] segment6 = new byte[0];
+                    byte[] segment7 = new byte[0];
+                    byte[] segment9 = new byte[0];
+                    byte[] popList = new byte[0];
+                    byte[] collisionList = new byte[0];
+                    byte[] renderList = new byte[0];
+
+
+                    byte[] popData = Resources.popResources;
+
+                    byte[] surfaceTable = new byte[0];
+                    byte[] displayTable = new byte[0];
+
+                    int magic = 0;
+
+                    int vertMagic = 0;
+
+                    // Game speed multiplier. Default is 2
+                    gameSpeed = new int[4];
+
+                    int.TryParse(sp1Box.Text, out gameSpeed[0]);
+                    int.TryParse(sp2Box.Text, out gameSpeed[1]);
+                    int.TryParse(sp3Box.Text, out gameSpeed[2]);
+                    int.TryParse(sp4Box.Text, out gameSpeed[3]);
+
+
+                    //Course Music
+
+                    byte songID = Convert.ToByte(songBox.SelectedIndex);
+
+
+                    // This command writes all the bitmaps to the end of the ROM
+
+                    rom = TarmacGeometry.writeTextures(rom, textureArray);
+                    segment9 = TarmacGeometry.compiletextureTable(textureArray);
+
+
+                    //build segment 7 out of the main course objects and surface geometry
+                    //build segment 4 out of the same objects.
+
+                    TM64_Geometry.OK64F3DObject[] textureObjects = masterObjects;
+                    byte[] tempBytes = new byte[0];
+                    if (levelFormat == 0)
+                    {
+                        int garbage = 0;
+                        TarmacGeometry.compileTextureObject(ref garbage, ref segment7, segment7, textureArray, vertMagic);
+                        TarmacGeometry.compileF3DObject(ref vertMagic, ref segment4, ref segment7, segment4, segment7, masterObjects, textureArray, vertMagic);
+                        TarmacGeometry.compileF3DObject(ref vertMagic, ref segment4, ref segment7, segment4, segment7, surfaceObjects, textureArray, vertMagic);
+
+
+                        // build various segment data
+                        
+
+                        renderList = TarmacGeometry.compileF3DList(ref sectionList, fbx, masterObjects, sectionList, textureArray);
+
+
+                        popList = tm64Path.popMarkers(popFile);
+
+
+                        surfaceTable = TarmacGeometry.compilesurfaceTable(surfaceObjects);
+
+                        magic = (8 + 8040 + 952 + 8 + 528 + (surfaceObjects.Length * 8));
+                        // 8 bytes for header
+                        // 8040 bytes for the POP data
+                        // 952 bytes for the POP resources
+                        // 8 bytes for Surface Table Footer
+                        // 528 bytes for the Display Table itself.
+                        // The surface table is 8 bytes per object.
+                        // We tracked the number of surface meshes while loading into surfaceObjects.
+                        // magic is the size of data written before the display lists.
+                        // it's needed to properly calculate the offsets.
+                        // We're calculating hardcoded offsets before writing them.
+                        // So we need to use magic to do it.
+
+                        // Build the display table with the above magic value
+
+                        displayTable = TarmacGeometry.compilesectionviewTable(sectionList, magic);
+
+
+
+
+
+                        bs = new MemoryStream();
+                        br = new BinaryReader(bs);
+                        bw = new BinaryWriter(bs);
+                        byte[] byteArray = new byte[0];
+
+                        byteArray = BitConverter.GetBytes(0xB8000000);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+                        byteArray = BitConverter.GetBytes(0x00000000);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+
+                        bw.Write(popList);
+                        bw.Write(popData);
+                        bw.Write(displayTable);
+                        bw.Write(surfaceTable);
+                        bw.Write(renderList);
+
+                        segment6 = bs.ToArray();
+                    }
+                    else
+                    {
+                        int battleOffset = 0;
+                        TarmacGeometry.compileBattleObject(ref battleOffset, ref vertMagic, ref segment4, ref segment7, segment4, segment7, masterObjects, textureArray, vertMagic);
+
+
+
+                        popList = tm64Path.popBattle(popFile);
+
+
+
+
+
+                        bs = new MemoryStream();
+                        br = new BinaryReader(bs);
+                        bw = new BinaryWriter(bs);
+                        byte[] byteArray = new byte[0];
+                        //FC121824FF33FFFF
+                        byteArray = BitConverter.GetBytes(0xFC121824);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+                        byteArray = BitConverter.GetBytes(0xFF33FFFF);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+                        //B900031D 00552078
+                        byteArray = BitConverter.GetBytes(0xB900031D);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+                        byteArray = BitConverter.GetBytes(0x00552078);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+
+                        byteArray = BitConverter.GetBytes(0x06000000);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+
+                        byteArray = BitConverter.GetBytes(battleOffset | 0x07000000);
+                        Array.Reverse(byteArray);
+                        bw.Write(byteArray);
+
+                        bw.Write(popList);
+
+                        segment6 = bs.ToArray();
+                    }
+
+                    //Compress appropriate segment data
+
+                    byte[] cseg7 = Tarmac.compress_seg7(segment7);
+
+
+
+                    string courseName = nameBox.Text;
+                    string previewImage = previewBox.Text;
+                    string bannerImage = bannerBox.Text;
+                    string mapImage = mapBox.Text;
+                    string customASM = asmBox.Text;
+                    string ghostData = ghostBox.Text;
+
+                    
+
+
+                    Int16[] mapCoords = new Int16[2];
+                    Int16[] startCoords = new Int16[2];
+
+                    Int16.TryParse(mapXBox.Text, out mapCoords[0]);
+                    Int16.TryParse(mapYBox.Text, out mapCoords[1]);
+                    Int16.TryParse(startXBox.Text, out startCoords[0]);
+                    Int16.TryParse(startYBox.Text, out startCoords[1]);
+
+                    
+
+                    int[] echoValues = new int[2];
+
+                    int.TryParse(EchoStartBox.Text, out echoValues[0]);
+                    int.TryParse(EchoStopBox.Text, out echoValues[1]);
+
+
+                    byte[] cseg4 = Tarmac.CompressMIO0(segment4);
+                    byte[] cseg6 = Tarmac.CompressMIO0(segment6);
+
+                    if (levelFormat == 0)
+                    {
+                        TM64_Course.Course courseData = new TM64_Course.Course();
+                        courseData.Segment4 = segment4;
+                        courseData.Segment6 = segment6;
+                        courseData.Segment7 = segment7;
+                        courseData.Segment9 = segment9;
+                        courseData.Credits = courseName;
+                        courseData.PreviewPath = previewImage;
+                        courseData.BannerPath = bannerImage;
+                        courseData.MapData = new TM64_Course.MiniMap();
+                        courseData.MapData.MinimapPath = mapImage;
+                        courseData.MapData.MapCoord = new Vector2D(mapCoords[0], mapCoords[1]);
+                        courseData.MapData.StartCoord = new Vector2D(startCoords[0], startCoords[1]);
+                        courseData.MapData.MapColor = mapData.MapColor;
+
+                        courseData.MasterObjects = masterObjects;
+                        courseData.SurfaceObjects = surfaceObjects;
+                        courseData.TextureObjects = textureArray;
+                        
+                        float tempfloat = new float();
+                        Single.TryParse(MapScaleBox.Text, out tempfloat);
+                        courseData.MapData.MapScale = tempfloat;
+
+
+                        courseData.EchoValues = echoValues;
+                        courseData.AssmeblyPath = customASM;
+                        courseData.GhostPath = ghostData;
+                        courseData.SkyColors = skyData;
+                        
+                        courseData.MusicID = songID;
+                        courseData.GameTempos = gameSpeed;
+                        courseData.PathLength = pathGroups[0].pathList[0].pathmarker.Count;
+
+                        Single.TryParse(waterBox.Text, out tempfloat);
+                        courseData.WaterLevel = tempfloat;
+
+                        rom = TarmacCourse.CompileOverKart(courseData,rom, cID, setID);
+                    }
+
+
+
+                    string savepath = "";
+
+                    savepath = Path.Combine(outputDirectory, "Mario Kart 64 (U) [!].z64");
+                    File.WriteAllBytes(savepath, rom);
+                    savepath = Path.Combine(outputDirectory, "Segment 4.bin");
+                    File.WriteAllBytes(savepath, segment4);
+
+                    savepath = Path.Combine(outputDirectory, "Compressed Segment 4.bin");
+                    File.WriteAllBytes(savepath, cseg4);
+
+                    savepath = Path.Combine(outputDirectory, "Segment 6.bin");
+                    File.WriteAllBytes(savepath, segment6);
+
+                    savepath = Path.Combine(outputDirectory, "Compressed Segment 6.bin");
+                    File.WriteAllBytes(savepath, cseg6);
+
+                    savepath = Path.Combine(outputDirectory, "Segment 7.bin");
+                    File.WriteAllBytes(savepath, segment7);
+
+                    savepath = Path.Combine(outputDirectory, "Compressed Segment 7.bin");
+                    File.WriteAllBytes(savepath, cseg7);
+
+                    savepath = Path.Combine(outputDirectory, "Segment 9.bin");
+                    File.WriteAllBytes(savepath, segment9);
+
+                    /*
+                     * Export OK64 CONFIG
+                     */
+                    ExportCourseInfo();
+
+                    MessageBox.Show("Finished");
+                } else
+                {
+                    throw new FileNotFoundException("Could not find overkart.z64 beside Tarmac executable");
+                }
         }
+        
 
 
         private void LoadModel()
         {
-            MessageBox.Show("Select .FBX File");
-            if (fileOpen.ShowDialog() == DialogResult.OK)
+            OpenFileDialog wpfDialog = new OpenFileDialog();
+            wpfDialog.InitialDirectory = okSettings.ProjectDirectory;
+            wpfDialog.Title = "Select .FBX File";
+            wpfDialog.FilterIndex = 2;
+            wpfDialog.Filter = "fbx files (*.fbx)|*.fbx";
+        if (wpfDialog.ShowDialog() ==  DialogResult.OK)
             {
+                okSettings.CurrentDirectory = System.IO.Path.GetDirectoryName(wpfDialog.FileName);
                 //Get the path of specified file
-                FBXfilePath = fileOpen.FileName;
+                FBXfilePath = wpfDialog.FileName;
+
                 levelFormat = 0;
 
                 if (raycastBox.Checked)
@@ -708,6 +1115,7 @@ namespace Tarmac64_Library
                     masterObjects = TarmacGeometry.loadMaster(ref masterGroups, fbx, textureArray);
 
                 }
+                masterBox.Nodes.Clear();
                 List<int> listedObjects = new List<int>();
 
 
@@ -721,9 +1129,52 @@ namespace Tarmac64_Library
                 }
                 for (int currentObject = 0; currentObject < surfaceObjects.Length; currentObject++)
                 {
-                    if (TarmacGeometry.CheckST(masterObjects[currentObject], textureArray[masterObjects[currentObject].materialID]))
+                    if (TarmacGeometry.CheckST(surfaceObjects[currentObject], textureArray[surfaceObjects[currentObject].materialID]))
                     {
-                        MessageBox.Show("Fatal UV Error " + masterObjects[currentObject].objectName);
+                        MessageBox.Show("Fatal UV Error " + surfaceObjects[currentObject].objectName);
+                    }
+                }
+
+                for (int currentGroup = 0; currentGroup < masterGroups.Length; currentGroup++)
+                {
+                    masterBox.Nodes.Add(masterGroups[currentGroup].groupName, masterGroups[currentGroup].groupName);
+                    for (int currentGrandchild = 0; currentGrandchild < masterGroups[currentGroup].subIndexes.Length; currentGrandchild++)
+                    {
+                        masterBox.Nodes[currentGroup].Nodes.Add(masterObjects[masterGroups[currentGroup].subIndexes[currentGrandchild]].objectName, masterObjects[masterGroups[currentGroup].subIndexes[currentGrandchild]].objectName);
+                        listedObjects.Add(masterGroups[currentGroup].subIndexes[currentGrandchild]);
+                    }
+                }
+                for (int currentMaster = 0; currentMaster < masterObjects.Length; currentMaster++)
+                {
+                    if (listedObjects.IndexOf(currentMaster) == -1)
+                    {
+                        masterBox.Nodes.Add(masterObjects[currentMaster].objectName, masterObjects[currentMaster].objectName);                            
+                    }
+                }
+                
+                if (levelFormat == 0)
+                {
+                    surfaceobjectBox.Items.Clear();
+                    for (int currentIndex = 0; currentIndex < surfaceObjects.Length; currentIndex++)
+                    {
+                        surfaceobjectBox.Items.Add(surfaceObjects[currentIndex].objectName);
+                    }
+                    sectionBox.Items.Clear();
+                    for (int currentSection = 0; currentSection < sectionCount; currentSection++)
+                    {
+                        surfsectionBox.Items.Add("Section " + (currentSection + 1).ToString());
+                        sectionBox.Items.Add("Section " + (currentSection + 1).ToString());
+
+                    }
+                    surfmaterialBox.Items.Clear();
+                    for (int surfacematerialIndex = 0; surfacematerialIndex < surfaceType.Length; surfacematerialIndex++)
+                    {
+                        surfmaterialBox.Items.Add(surfaceTypeID[surfacematerialIndex].ToString("X") + "- " + surfaceType[surfacematerialIndex]);
+                    }
+                    viewBox.Items.Clear();
+                    foreach (var viewstring in viewString)
+                    {
+                        viewBox.Items.Add(viewstring);
                     }
                 }
 
@@ -752,10 +1203,8 @@ namespace Tarmac64_Library
                 }
                 if (levelFormat == 0)
                 {
-                    
-                    mcountBox.Text = materialCount.ToString();
-                    tcountBox.Text = textureCount.ToString();
-
+                    viewBox.SelectedIndex = 0;
+                    sectionBox.SelectedIndex = 0;
                     textureBox.SelectedIndex = 0;
                     lastMaterial = 0;
 
@@ -765,10 +1214,12 @@ namespace Tarmac64_Library
                 actionBtn.Text = "Compile";
             }
 
-            MessageBox.Show("Select OK64.POP File");
-            if (fileOpen.ShowDialog() == DialogResult.OK)
+            /**
+             * Read OK64.POP File
+             */
+            if (File.Exists(okSettings.CurrentDirectory + "\\POP.OK64"))
             {
-                popFile = fileOpen.FileName;
+                popFile = okSettings.CurrentDirectory + "\\POP.OK64";
                 if (levelFormat == 0)
                 {
                     pathGroups = tm64Path.loadPOP(popFile, surfaceObjects);
@@ -778,9 +1229,18 @@ namespace Tarmac64_Library
                     pathGroups = tm64Path.loadBattlePOP(popFile);
                 }
             }
+            else
+            {
+                throw new FileNotFoundException("Error: Place 'OK64.POP' file beside the FBX file.\nIt must be named 'OK64.POP'");
+            }
             openGLControl.Visible = true;
             openGLControl.Enabled = true;
-            
+
+
+            /*
+             * Import OK64 CONFIG
+             */
+             ImportCourseInfo();
         }
 
 
@@ -829,17 +1289,83 @@ namespace Tarmac64_Library
 
         private void UpdateSVDisplay()
         {
-            
+            if (!updateBool)
+            {
+                updateBool = true;
+                if (loaded == true)
+                {
+                    int vertCount = 0;
+                    int faceCount = 0;
+                    for (int currentTree = 0; currentTree < masterBox.Nodes.Count; currentTree++)
+                    {
+                        if (masterBox.Nodes[currentTree].Nodes.Count > 0)
+                        {
+                            for (int currentNode = 0; currentNode < masterBox.Nodes[currentTree].Nodes.Count; currentNode++)
+                            {
+                                masterBox.Nodes[currentTree].Nodes[currentNode].Checked = false;
+                            }
+                        }
+                        else
+                        {
+                            masterBox.Nodes[currentTree].Checked = false;
+                        }
+                    }
+                    foreach (var subObject in sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList)
+                    {
+
+                        TreeNode[] thisNode = masterBox.Nodes.Find(masterObjects[subObject].objectName, true);
+                        thisNode[0].Checked = true;
+                        vertCount = vertCount + masterObjects[subObject].vertCount;
+                        faceCount = faceCount + masterObjects[subObject].faceCount;
+
+                    }
+                    updateCounter(faceCount);
+                }
+                updateBool = false;
+            }
         }
         //Seperate loading the counters to prevent infinite loop. 
         private void updateCounter(int faceCount)
         {
-           
+            int objectCount = 0;
+            faceBox.Text = faceCount.ToString();
+            for (int currentTree = 0; currentTree < masterBox.Nodes.Count; currentTree++)
+            {
+                if (masterBox.Nodes[currentTree].Nodes.Count > 0)
+                {
+                    for (int currentNode = 0; currentNode < masterBox.Nodes[currentTree].Nodes.Count; currentNode++)
+                    {
+                        if (masterBox.Nodes[currentTree].Nodes[currentNode].Checked == true)
+                        {
+                            objectCount++;
+                        }
+                    }
+                }
+                else
+                {
+                    if (masterBox.Nodes[currentTree].Checked == true)
+                    {
+                        objectCount++;
+                    }
+                }
+            }
+            objectBox.Text = objectCount.ToString();
         }
         //
         private void updateSMDisplay()
         {
+            if (loaded == true)
+            {
+                int objectIndex = surfaceobjectBox.SelectedIndex;
 
+                surfsectionBox.SelectedIndex = surfaceObjects[objectIndex].surfaceID - 1;
+                int materialIndex = Array.IndexOf(surfaceTypeID, surfaceObjects[objectIndex].surfaceMaterial);
+                surfmaterialBox.SelectedIndex = materialIndex;
+                surfpropertybox.SelectedIndex = surfaceObjects[objectIndex].surfaceProperty;
+
+                surfvertBox.Text = surfaceObjects[objectIndex].vertCount.ToString();
+                surffaceBox.Text = surfaceObjects[objectIndex].faceCount.ToString();
+            }
         }
 
         private bool updateTXDisplay()
@@ -847,6 +1373,15 @@ namespace Tarmac64_Library
             if (textureArray[textureBox.SelectedIndex].texturePath != null)
             {
                 bitm.ImageLocation = textureArray[textureBox.SelectedIndex].texturePath;
+                heightBox.Text = textureArray[textureBox.SelectedIndex].textureHeight.ToString();
+                widthBox.Text = textureArray[textureBox.SelectedIndex].textureWidth.ToString();
+                textureModeSBox.SelectedIndex = textureArray[textureBox.SelectedIndex].textureModeS;
+                textureModeTBox.SelectedIndex = textureArray[textureBox.SelectedIndex].textureModeT;
+                textureAlphaBox.SelectedIndex = textureArray[textureBox.SelectedIndex].textureTransparent;
+                textureCodecBox.SelectedIndex = textureArray[textureBox.SelectedIndex].textureCodec;
+                textureScrollSBox.Text = textureArray[textureBox.SelectedIndex].textureScrollS.ToString();
+                textureScrollTBox.Text = textureArray[textureBox.SelectedIndex].textureScrollT.ToString();
+                vertAlphaBox.Text = textureArray[textureBox.SelectedIndex].vertAlpha.ToString();
                 return true;
             }
             else
@@ -856,6 +1391,51 @@ namespace Tarmac64_Library
         }
 
 
+        private void ObjectBox_ItemCheck(object sender, ItemCheckEventArgs e)
+        {
+
+            this.BeginInvoke(new MethodInvoker(CheckList), null);
+        }
+
+        private void CheckList()
+        {
+            if (loaded == true)
+            {
+                int vertCount = 0;
+                int faceCount = 0;
+                int currentIndex = 0;
+                List<int> checkList = new List<int>();
+                for (int currentTree = 0; currentTree < masterBox.Nodes.Count; currentTree++)
+                {
+                    currentIndex++;
+                    if (masterBox.Nodes[currentTree].Nodes.Count > 0)
+                    {
+                        for (int currentNode = 0; currentNode < masterBox.Nodes[currentTree].Nodes.Count; currentNode++)
+                        {
+                            currentIndex++;
+                            if (masterBox.Nodes[currentTree].Nodes[currentNode].Checked == true)
+                            {
+                                checkList.Add(currentIndex);
+                                vertCount = vertCount + masterObjects[currentIndex].vertCount;
+                                faceCount = faceCount + masterObjects[currentIndex].faceCount;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (masterBox.Nodes[currentTree].Checked == true)
+                        {
+                            checkList.Add(currentIndex);
+                            vertCount = vertCount + masterObjects[currentIndex].vertCount;
+                            faceCount = faceCount + masterObjects[currentIndex].faceCount;
+                        }
+                    }
+                }
+                sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList = checkList.ToArray();
+
+                updateCounter(faceCount);
+            }
+        }
 
         private void Formatbox_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -877,12 +1457,14 @@ namespace Tarmac64_Library
 
         private void SurfsectionBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-           
+            surfaceObjects[surfaceobjectBox.SelectedIndex].surfaceID = surfsectionBox.SelectedIndex + 1;
         }
 
         private void SurfmaterialBox_SelectedIndexChanged(object sender, EventArgs e)
         {
- 
+            string[] surfacesplit = surfmaterialBox.Items[surfmaterialBox.SelectedIndex].ToString().Split('-');
+            int surfaceIndex = Convert.ToInt32(surfacesplit[0], 16);
+            surfaceObjects[surfaceobjectBox.SelectedIndex].surfaceMaterial = Convert.ToByte(surfaceIndex);
         }
 
         private void Rtbox_TextChanged(object sender, EventArgs e)
@@ -923,25 +1505,119 @@ namespace Tarmac64_Library
             skyDialog.ShowHelp = true;
 
 
-            
+            int rr = 0;
+            int.TryParse(SkyRT.Text, out rr);
+            int gg = 0;
+            int.TryParse(SkyGT.Text, out gg);
+            int bb = 0;
+            int.TryParse(SkyBT.Text, out bb);
+            System.Drawing.Color buttonColor = System.Drawing.Color.FromArgb(rr, gg, bb);
+
+            skyDialog.Color = buttonColor;
+
+            // Update the text box color if the user clicks OK 
+            if (skyDialog.ShowDialog() == DialogResult.OK)
+            {
+                buttonColor = skyDialog.Color;
+                SkyRT.Text = skyDialog.Color.R.ToString();
+                SkyGT.Text = skyDialog.Color.G.ToString();
+                SkyBT.Text = skyDialog.Color.B.ToString();
+            }
+            ColorUpdate();
 
         }
 
         private void Cpbot_Click(object sender, EventArgs e)
         {
-            
+            ColorDialog skyDialog = new ColorDialog();
+
+            skyDialog.AllowFullOpen = true;
+            skyDialog.ShowHelp = true;
+
+
+            int rr = 0;
+            int.TryParse(SkyRM.Text, out rr);
+            int gg = 0;
+            int.TryParse(SkyGM.Text, out gg);
+            int bb = 0;
+            int.TryParse(SkyBM.Text, out bb);
+            System.Drawing.Color buttonColor = System.Drawing.Color.FromArgb(rr, gg, bb);
+
+            skyDialog.Color = buttonColor;
+
+            // Update the text box color if the user clicks OK 
+            if (skyDialog.ShowDialog() == DialogResult.OK)
+            {
+                buttonColor = skyDialog.Color;
+                SkyRM.Text = skyDialog.Color.R.ToString();
+                SkyGM.Text = skyDialog.Color.G.ToString();
+                SkyBM.Text = skyDialog.Color.B.ToString();
+            }
+            ColorUpdate();
 
         }
 
 
         private void PreviewBtn_Click(object sender, EventArgs e)
         {
-            if (fileOpen.ShowDialog() == DialogResult.OK)
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
             {
                 //Get the path of specified file
+                previewBox.Text = fileOpen.FileName;
             }
         }
 
+        private void BannerBtn_Click(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                //Get the path of specified file
+                bannerBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void MapBtn_Click(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                //Get the path of specified file
+                mapBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void AsmBtn_Click(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                //Get the path of specified file
+                asmBox.Text = fileOpen.FileName;
+            }
+        }
+
+
+        private void ghostbtn_Click(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                //Get the path of specified file
+                ghostBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void tBox_CheckedChanged(object sender, EventArgs e)
+        {
+            
+        }
 
 
 
@@ -1090,6 +1766,218 @@ namespace Tarmac64_Library
             List<string> drawnObjects = new List<string>();
             //draw faces
 
+            switch (tabControl1.SelectedIndex)
+            {
+                case 2:
+                    {
+
+
+
+                        for (int subIndex = 0; subIndex < masterObjects.Length; subIndex++)
+                        {
+
+                            if (subIndex == highlightedObject)
+                            {
+                                if (chkHover.Checked)
+                                {
+                                    gl = TarmacGL.DrawTarget(gl, localCamera, glTexture, masterObjects[subIndex]);
+                                }
+                                else
+                                {
+                                    if (Array.IndexOf(sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList, subIndex) != -1)
+                                    {
+                                        if (CheckboxTextured.Checked)
+                                        {
+                                            gl = TarmacGL.DrawTextured(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                        }
+                                        else
+                                        {
+                                            gl = TarmacGL.DrawShaded(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                        }
+                                    }
+                                    else if (chkWireframe.Checked)
+                                    {
+                                        gl = TarmacGL.DrawWire(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                    }
+                                }
+                            }
+                            else
+                            {
+
+                                if (Array.IndexOf(sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList, subIndex) != -1)
+                                {
+                                    if (CheckboxTextured.Checked)
+                                    {
+                                        gl = TarmacGL.DrawTextured(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                    }
+                                    else
+                                    {
+                                        gl = TarmacGL.DrawShaded(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                    }
+                                }
+                                else if (chkWireframe.Checked)
+                                {
+                                    gl = TarmacGL.DrawWire(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                }
+                            }
+
+                        }
+
+                        if (chkSection.Checked)
+                        {
+                            foreach (var subObject in surfaceObjects)
+                            {
+                                if (subObject.surfaceID == (sectionBox.SelectedIndex + 1))
+                                {
+                                    gl = TarmacGL.DrawSection(gl, localCamera, glTexture, subObject);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                case 3:
+                    {
+                        for (int subIndex = 0; subIndex < surfaceObjects.Length; subIndex++)
+                        {
+                            if (subIndex == highlightedObject)
+                            {
+                                if (chkHover.Checked)
+                                {
+                                    gl = TarmacGL.DrawTarget(gl, localCamera, glTexture, surfaceObjects[subIndex]);
+                                }
+                                else
+                                {
+                                    if (Array.IndexOf(sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList, subIndex) != -1)
+                                    {
+                                        if (CheckboxTextured.Checked)
+                                        {
+                                            gl = TarmacGL.DrawTextured(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                        }
+                                        else
+                                        {
+                                            gl = TarmacGL.DrawShaded(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                        }
+                                    }
+                                    else if (chkWireframe.Checked)
+                                    {
+                                        gl = TarmacGL.DrawWire(gl, textureArray, localCamera, glTexture, masterObjects[subIndex]);
+                                    }
+                                }
+                            }
+                            foreach (var face in surfaceObjects[subIndex].modelGeometry)
+                            {
+                                gl = TarmacGL.DrawShaded(gl, glTexture, face, surfaceObjects[subIndex].objectColor);
+                            }
+                        }
+                        break;
+                    }
+                default:
+                    {
+
+                        foreach (var subObject in masterObjects)
+                        {
+                            if (CheckboxTextured.Checked)
+                            {
+                                gl = TarmacGL.DrawTextured(gl, textureArray, localCamera, glTexture, subObject);
+                            }
+                            else
+                            {
+                                gl = TarmacGL.DrawShaded(gl, textureArray, localCamera, glTexture, subObject);
+                            }
+                        }
+                        break;
+                    }
+            }
+
+            if (levelFormat == 0)
+            {
+                if (chkPop.Checked)
+                {
+
+                    foreach (var list in pathGroups[0].pathList)
+                    {
+                        float[] surfaceYellow = GetYellowFlash(flashYellow);
+                        gl.End();
+                        gl.PolygonMode(OpenGL.GL_FRONT_AND_BACK, OpenGL.GL_FILL);
+                        glTexture.Destroy(gl);
+                        gl.Begin(OpenGL.GL_TRIANGLES);
+                        foreach (var marker in list.pathmarker)
+                        {
+                            DrawMarker(markerGeometry, marker, surfaceYellow);
+                        }
+                    }
+                    foreach (var list in pathGroups[1].pathList)
+                    {
+                        float[] color = { 0.5f, 0f, 1.0f };
+                        gl.End();
+                        gl.PolygonMode(OpenGL.GL_FRONT_AND_BACK, OpenGL.GL_FILL);
+                        glTexture.Destroy(gl);
+                        gl.Begin(OpenGL.GL_TRIANGLES);
+                        foreach (var marker in list.pathmarker)
+                        {
+                            DrawMarker(itemGeometry, marker, color);
+                        }
+                    }
+                    foreach (var list in pathGroups[2].pathList)
+                    {
+                        if (CheckboxTextured.Checked)
+                        {
+                            gl.End();
+                            glTexture.Destroy(gl);
+                            gl.Enable(OpenGL.GL_TEXTURE_2D);
+
+                            glTexture.Create(gl, Resources.Tree1);
+                            glTexture.Bind(gl);
+                            gl.PolygonMode(OpenGL.GL_FRONT_AND_BACK, OpenGL.GL_FILL);
+                            gl.Begin(OpenGL.GL_TRIANGLES);
+                            foreach (var marker in list.pathmarker)
+                            {
+                                DrawTree(treeGeometry, marker);
+                            }
+                            gl.End();
+                        }
+                        else
+                        {
+                            float[] color = { 1.0f, 0.5f, 0 };
+                            gl.End();
+                            gl.PolygonMode(OpenGL.GL_FRONT_AND_BACK, OpenGL.GL_FILL);
+                            glTexture.Destroy(gl);
+                            gl.Begin(OpenGL.GL_TRIANGLES);
+                            foreach (var marker in list.pathmarker)
+                            {
+                                DrawMarker(piranhaGeometry, marker, color);
+                            }
+                        }
+
+
+
+                    }
+                    foreach (var list in pathGroups[3].pathList)
+                    {
+                        float[] color = { 1.0f, 0.5f, 0 };
+                        gl.End();
+                        gl.PolygonMode(OpenGL.GL_FRONT_AND_BACK, OpenGL.GL_FILL);
+                        glTexture.Destroy(gl);
+                        gl.Begin(OpenGL.GL_TRIANGLES);
+                        foreach (var marker in list.pathmarker)
+                        {
+                            DrawMarker(piranhaGeometry, marker, color);
+                        }
+                    }
+                    foreach (var list in pathGroups[4].pathList)
+                    {
+                        float[] color = { 1.0f, 0, 0 };
+                        gl.End();
+                        gl.PolygonMode(OpenGL.GL_FRONT_AND_BACK, OpenGL.GL_FILL);
+                        glTexture.Destroy(gl);
+                        gl.Begin(OpenGL.GL_TRIANGLES);
+                        foreach (var marker in list.pathmarker)
+                        {
+                            DrawMarker(redcoinGeometry, marker, color);
+                        }
+                    }
+                }
+            }
             
             loadGL = true;
         }
@@ -1322,22 +2210,7 @@ namespace Tarmac64_Library
 
         }
 
-
-        //
-
-        //
-
-        //
-
-        //
-
-
-
-
-        
-
-
-        private void Button1_Click_1(object sender, EventArgs e)
+        private void ExportBtn_Click(object sender, EventArgs e)
         {
             SaveFileDialog saveFile = new SaveFileDialog();
             if (saveFile.ShowDialog() == DialogResult.OK)
@@ -1345,7 +2218,7 @@ namespace Tarmac64_Library
                 string filePath = saveFile.FileName;
 
                 TM64_Geometry TarmacGeometry = new TM64_Geometry();
-                TarmacGeometry.ExportSVL(filePath, masterObjects.Length, sectionList, masterObjects);                
+                TarmacGeometry.ExportSVL(filePath, masterObjects.Length, sectionList, masterObjects);
             }
         }
 
@@ -1370,7 +2243,6 @@ namespace Tarmac64_Library
                 }
             }
         }
-
         private void button2_Click(object sender, EventArgs e)
         {
             
@@ -1412,6 +2284,117 @@ namespace Tarmac64_Library
 
         }
 
+        private void surfacepropertybox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            surfaceObjects[surfaceobjectBox.SelectedIndex].surfaceProperty = surfpropertybox.SelectedIndex;
+        }
+
+        private void openGLControl_MouseClick(object sender, System.Windows.Forms.MouseEventArgs e)
+        {
+            System.Windows.Point mouseClick = new System.Windows.Point(e.Location.X, e.Location.Y);
+
+            double[] pointA = gl.UnProject(e.Location.X, e.Location.Y, 0);
+            double[] pointB = gl.UnProject(e.Location.X, e.Location.Y, 1);
+
+            Vector3D rayOrigin = new Vector3D(Convert.ToSingle(pointA[0]), Convert.ToSingle(pointA[1]), Convert.ToSingle(pointA[2]));
+            Vector3D rayTarget = new Vector3D(Convert.ToSingle(pointB[0]), Convert.ToSingle(pointB[1]), Convert.ToSingle(pointB[2] * -1));
+
+
+            float objectDistance = -1;
+            TM64_Geometry tmGeo = new TM64_Geometry();
+            int objectID = -1;
+            cName.Text = "";
+            
+            switch (tabControl1.SelectedIndex)
+            {
+                default:
+                    {
+                        break;
+                    }
+                case 2:
+                    {
+                        for (int currentObject = 0; (currentObject < masterObjects.Length); currentObject++)
+                        {
+
+                            foreach (var face in masterObjects[currentObject].modelGeometry)
+                            {
+
+                                Vector3D intersectPoint = tmGeo.testIntersect(rayOrigin, rayTarget, face.VertData[0], face.VertData[1], face.VertData[2]);
+                                if (intersectPoint.X > 0)
+                                {
+                                    if (objectDistance > intersectPoint.X | objectDistance == -1)
+                                    {
+                                        objectDistance = intersectPoint.X;
+                                        objectID = currentObject;
+                                        cName.Text = masterObjects[currentObject].objectName;
+                                    }
+                                }
+                                else
+                                {
+
+                                }
+                            }
+                        }
+                        if (objectID > -1)
+                        {
+                            var SelectedNodes = masterBox.Nodes.Find(masterObjects[objectID].objectName, true);
+                            
+                            masterBox.SelectedNode = SelectedNodes[0];
+                            if (e.Button == MouseButtons.Right)
+                            {
+                                SelectedNodes[0].Checked = !SelectedNodes[0].Checked;
+                                updateSectionList(masterObjects[objectID].objectName);
+                            }
+                            else
+                            {
+                                masterBox.Focus();
+                            }
+                            
+                        }
+
+                        break;
+                    }
+                case 3:
+                    {
+                        for (int currentObject = 0; (currentObject < surfaceObjects.Length); currentObject++)
+                        {
+
+                            foreach (var face in surfaceObjects[currentObject].modelGeometry)
+                            {
+
+                                Vector3D intersectPoint = tmGeo.testIntersect(rayOrigin, rayTarget, face.VertData[0], face.VertData[1], face.VertData[2]);
+                                if (intersectPoint.X > 0)
+                                {
+                                    if (objectDistance > intersectPoint.X | objectDistance == -1)
+                                    {
+                                        objectDistance = intersectPoint.X;
+                                        objectID = currentObject;
+                                        cName.Text = surfaceObjects[currentObject].objectName;
+                                    }
+                                }
+                                else
+                                {
+
+                                }
+                            }
+                        }
+                        if (objectID > -1)
+                        {
+                            surfaceobjectBox.SelectedIndex = objectID;
+                            if (e.Button == MouseButtons.Left)
+                            {
+                                surfaceobjectBox.Focus();
+                            }
+                        }
+
+                        break;
+                    }
+                    
+
+            }
+        }
+
+
         private void openGLControl_MouseMove(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             System.Windows.Point mouseClick = new System.Windows.Point(e.Location.X, e.Location.Y);
@@ -1427,29 +2410,307 @@ namespace Tarmac64_Library
             TM64_Geometry tmGeo = new TM64_Geometry();
             int objectID = -1;
             cName.Text = "";
-            for (int currentObject = 0; (currentObject < masterObjects.Length); currentObject++)
+
+
+
+            switch (tabControl1.SelectedIndex)
             {
-
-                foreach (var face in masterObjects[currentObject].modelGeometry)
-                {
-
-                    Vector3D intersectPoint = tmGeo.testIntersect(rayOrigin, rayTarget, face.VertData[0], face.VertData[1], face.VertData[2]);
-                    if (intersectPoint.X > 0)
+                default:
                     {
-                        if (objectDistance > intersectPoint.X | objectDistance == -1)
+                        break;
+                    }
+                case 2:
+                    {
+
+                        for (int currentObject = 0; (currentObject < masterObjects.Length); currentObject++)
                         {
-                            objectDistance = intersectPoint.X;
-                            objectID = currentObject;
-                            cName.Text = masterObjects[currentObject].objectName;
+
+                            foreach (var face in masterObjects[currentObject].modelGeometry)
+                            {
+
+                                Vector3D intersectPoint = tmGeo.testIntersect(rayOrigin, rayTarget, face.VertData[0], face.VertData[1], face.VertData[2]);
+                                if (intersectPoint.X > 0)
+                                {
+                                    if (objectDistance > intersectPoint.X | objectDistance == -1)
+                                    {
+                                        objectDistance = intersectPoint.X;
+                                        objectID = currentObject;
+                                        cName.Text = masterObjects[currentObject].objectName;
+                                    }
+                                }
+                                else
+                                {
+
+                                }
+                            }
                         }
+
+                        break;
+                    }
+                case 3:
+                    {
+
+                        for (int currentObject = 0; (currentObject < surfaceObjects.Length); currentObject++)
+                        {
+
+                            foreach (var face in surfaceObjects[currentObject].modelGeometry)
+                            {
+
+                                Vector3D intersectPoint = tmGeo.testIntersect(rayOrigin, rayTarget, face.VertData[0], face.VertData[1], face.VertData[2]);
+                                if (intersectPoint.X > 0)
+                                {
+                                    if (objectDistance > intersectPoint.X | objectDistance == -1)
+                                    {
+                                        objectDistance = intersectPoint.X;
+                                        objectID = currentObject;
+                                        cName.Text = surfaceObjects[currentObject].objectName;
+                                    }
+                                }
+                                else
+                                {
+
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+
+
+            }
+            highlightedObject = objectID;
+        }
+
+        private void updateSectionList(string objectName)
+        {
+            List<int> objectList = sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList.ToList();
+            int objectIndex = -1;
+            for (int currentObject = 0; currentObject < masterObjects.Length; currentObject++)
+            {                
+                if (masterObjects[currentObject].objectName == objectName)
+                {
+                    objectIndex = currentObject;
+                    break;
+                }
+            }
+            if (objectIndex > -1)
+            {
+                int objectCount = objectList.Count; //this value is dynamic as we add/remove items.
+                for (int currentObject = 0; currentObject < objectCount; currentObject++)
+                {
+                    if (currentObject < objectList.Count) //dynamic
+                    {
+                        if (objectList[currentObject] == objectIndex)
+                        {
+                            objectList.RemoveAt(currentObject);
+                            break;
+                        }
+                        else
+                        {
+                            if (currentObject + 1 == objectList.Count)
+                            {
+                                objectList.Add(objectIndex);
+                            }
+                        }
+                    }
+                }
+                sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList = objectList.ToArray();
+            }
+            UpdateSVDisplay();
+        }
+
+        private void masterBox_AfterCheck(object sender, TreeViewEventArgs e)
+        {
+            if (e.Action != TreeViewAction.Unknown)
+            {
+                List<int> checkList = new List<int>();
+                bool checkState = e.Node.Checked;
+                checkList = sectionList[sectionBox.SelectedIndex].viewList[viewBox.SelectedIndex].objectList.ToList();
+                int faceCount = 0;
+                if (loaded == true)
+                {
+                    if (e.Node.Nodes.Count > 0)
+                    {
+                        
+                        foreach (TreeNode childNode in e.Node.Nodes)
+                        {
+                            childNode.Checked = checkState;
+                            updateSectionList(childNode.Name);
+                        }
+                        
+
                     }
                     else
                     {
-
+                        updateSectionList(e.Node.Name);
                     }
+                    
+                    
                 }
             }
-            highlightedObject = objectID;
+        }
+
+
+        private void ColorPickT_Click(object sender, EventArgs e)
+        {
+            ColorDialog ColorPick = new ColorDialog();
+            if (ColorPick.ShowDialog() == DialogResult.OK)
+            {
+                SkyRT.Text = ColorPick.Color.R.ToString();
+                SkyGT.Text = ColorPick.Color.G.ToString();
+                SkyBT.Text = ColorPick.Color.B.ToString();
+            }
+            ColorUpdate();
+        }
+
+        private void ColorPickMT_Click(object sender, EventArgs e)
+        {
+            ColorDialog ColorPick = new ColorDialog();
+            if (ColorPick.ShowDialog() == DialogResult.OK)
+            {
+                SkyRM.Text = ColorPick.Color.R.ToString();
+                SkyGM.Text = ColorPick.Color.G.ToString();
+                SkyBM.Text = ColorPick.Color.B.ToString();
+            }
+            ColorUpdate();
+        }
+
+        private void SkyGT_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void SkyRT_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void SkyBT_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void SkyRMT_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void SkyBMT_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void SkyGMT_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+
+        private void SkyBB_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void SkyGB_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+
+        private void SkyRB_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+
+
+        private void ColorPickB_Click(object sender, EventArgs e)
+        {
+            ColorDialog ColorPick = new ColorDialog();
+            if (ColorPick.ShowDialog() == DialogResult.OK)
+            {
+                SkyRB.Text = ColorPick.Color.R.ToString();
+                SkyGB.Text = ColorPick.Color.G.ToString();
+                SkyBB.Text = ColorPick.Color.B.ToString();
+            }
+            ColorUpdate();
+        }
+
+        private void ColorPickMap_Click(object sender, EventArgs e)
+        {
+            ColorDialog ColorPick = new ColorDialog();
+            if (ColorPick.ShowDialog() == DialogResult.OK)
+            {
+                MapRBox.Text = ColorPick.Color.R.ToString();
+                MapGBox.Text = ColorPick.Color.G.ToString();
+                MapBBox.Text = ColorPick.Color.B.ToString();
+            }
+            ColorUpdate();
+        }
+
+        private void previewBtn_Click_1(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                previewBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void bannerBtn_Click_1(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                bannerBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void ghostBtn_Click_1(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                ghostBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void asmBtn_Click_1(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                asmBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void mapBtn_Click_1(object sender, EventArgs e)
+        {
+            fileOpen.InitialDirectory = okSettings.ProjectDirectory;
+            fileOpen.IsFolderPicker = false;
+            if (fileOpen.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                mapBox.Text = fileOpen.FileName;
+            }
+        }
+
+        private void MapG_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void MapB_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
+        }
+
+        private void MapR_TextChanged(object sender, EventArgs e)
+        {
+            ColorUpdate();
         }
 
         private void contextMenuStrip1_Opening(object sender, CancelEventArgs e)
@@ -1460,6 +2721,187 @@ namespace Tarmac64_Library
         private void button2_Click_1(object sender, EventArgs e)
         {
 
+        }
+
+        private void textureModeBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            textureArray[textureBox.SelectedIndex].textureModeS = textureModeSBox.SelectedIndex;
+        }
+
+        private void textureAlphaBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            textureArray[textureBox.SelectedIndex].textureTransparent = textureAlphaBox.SelectedIndex;
+        }
+
+        private void textureCodecBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            textureArray[textureBox.SelectedIndex].textureCodec = textureCodecBox.SelectedIndex;
+        }
+
+        private void textureModeTBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            textureArray[textureBox.SelectedIndex].textureModeT = textureModeTBox.SelectedIndex;
+        }
+
+        private void ExportCourseInfo()
+        {
+            gameSpeed = new int[4];
+
+            int.TryParse(sp1Box.Text, out gameSpeed[0]);
+            int.TryParse(sp2Box.Text, out gameSpeed[1]);
+            int.TryParse(sp3Box.Text, out gameSpeed[2]);
+            int.TryParse(sp4Box.Text, out gameSpeed[3]);
+
+
+            //Course Music
+
+            byte songID = Convert.ToByte(songBox.SelectedIndex);
+
+
+
+
+            string courseName = nameBox.Text;
+            string previewImage = previewBox.Text;
+            string bannerImage = bannerBox.Text;
+            string mapImage = mapBox.Text;
+            string customASM = asmBox.Text;
+            string ghostData = ghostBox.Text;
+
+
+
+
+            Int16[] mapCoords = new Int16[2];
+            Int16[] startCoords = new Int16[2];
+
+            Int16.TryParse(mapXBox.Text, out mapCoords[0]);
+            Int16.TryParse(mapYBox.Text, out mapCoords[1]);
+            Int16.TryParse(startXBox.Text, out startCoords[0]);
+            Int16.TryParse(startYBox.Text, out startCoords[1]);
+
+
+
+            int[] echoValues = new int[2];
+
+            int.TryParse(EchoStartBox.Text, out echoValues[0]);
+            int.TryParse(EchoStopBox.Text, out echoValues[1]);
+
+            TM64_Course.Course courseData = new TM64_Course.Course();
+            courseData.Credits = courseName;
+            courseData.PreviewPath = previewImage;
+            courseData.BannerPath = bannerImage;
+            courseData.MapData = new TM64_Course.MiniMap();
+            courseData.MapData.MinimapPath = mapImage;
+            courseData.MapData.MapCoord = new Vector2D(mapCoords[0], mapCoords[1]);
+            courseData.MapData.StartCoord = new Vector2D(startCoords[0], startCoords[1]);
+            courseData.MapData.MapColor = mapData.MapColor;
+
+            float tempfloat = new float();
+            Single.TryParse(MapScaleBox.Text, out tempfloat);
+            courseData.MapData.MapScale = tempfloat;
+
+
+            courseData.EchoValues = echoValues;
+            courseData.AssmeblyPath = customASM;
+            courseData.GhostPath = ghostData;
+            courseData.SkyColors = skyData;
+
+            courseData.MusicID = songID;
+            courseData.GameTempos = gameSpeed;
+            courseData.PathLength = pathGroups[0].pathList[0].pathmarker.Count;
+
+            Single.TryParse(waterBox.Text, out tempfloat);
+            courseData.WaterLevel = tempfloat;
+
+            if (!File.Exists(okSettings.CurrentDirectory + "\\CONFIG.OK64"))
+            {
+                File.Create(okSettings.CurrentDirectory + "\\CONFIG.OK64");
+            }
+            if (File.Exists(okSettings.CurrentDirectory + "\\CONFIG.OK64"))
+            {
+                TM64_Course TarmacCourse = new TM64_Course();
+                TarmacCourse.WriteCourseInfo(courseData, okSettings.CurrentDirectory + "\\CONFIG.OK64");
+            } else {
+                throw new FileNotFoundException("ERROR: Could not write CONFIG.OK64");
+            }
+        }
+
+        private void ImportCourseInfo()
+        {
+            if (File.Exists(okSettings.CurrentDirectory + "\\CONFIG.OK64"))
+            {
+                TM64_Course TarmacCourse = new TM64_Course();
+                TM64_Course.Course CourseData = TarmacCourse.ReadCourseInfo(okSettings.CurrentDirectory + "\\CONFIG.OK64");
+                if (CourseData != null)
+                {
+                    nameBox.Text = CourseData.Credits;
+                    previewBox.Text = CourseData.PreviewPath;
+                    bannerBox.Text = CourseData.BannerPath;
+                    ghostBox.Text = CourseData.GhostPath;
+                    asmBox.Text = CourseData.AssmeblyPath;
+                    mapBox.Text = CourseData.MapData.MinimapPath;
+                    mapXBox.Text = CourseData.MapData.MapCoord.X.ToString();
+                    mapYBox.Text = CourseData.MapData.MapCoord.Y.ToString();
+                    startXBox.Text = CourseData.MapData.StartCoord.X.ToString();
+                    startYBox.Text = CourseData.MapData.StartCoord.Y.ToString();
+                    MapScaleBox.Text = CourseData.MapData.MapScale.ToString();
+                    MapRBox.Text = CourseData.MapData.MapColor.R.ToString();
+                    MapRBox.Text = CourseData.MapData.MapColor.G.ToString();
+                    MapRBox.Text = CourseData.MapData.MapColor.B.ToString();
+                    SkyRT.Text = CourseData.SkyColors.TopColor.R.ToString();
+                    SkyGT.Text = CourseData.SkyColors.TopColor.G.ToString();
+                    SkyBT.Text = CourseData.SkyColors.TopColor.B.ToString();
+
+                    SkyRM.Text = CourseData.SkyColors.MidColor.R.ToString();
+                    SkyGM.Text = CourseData.SkyColors.MidColor.G.ToString();
+                    SkyBM.Text = CourseData.SkyColors.MidColor.B.ToString();
+
+                    SkyRB.Text = CourseData.SkyColors.BotColor.R.ToString();
+                    SkyGB.Text = CourseData.SkyColors.BotColor.G.ToString();
+                    SkyBB.Text = CourseData.SkyColors.BotColor.B.ToString();
+
+                    EchoStartBox.Text = CourseData.EchoValues[0].ToString();
+                    EchoStopBox.Text = CourseData.EchoValues[1].ToString();
+                    waterBox.Text = CourseData.WaterLevel.ToString();
+                    sp1Box.Text = CourseData.GameTempos[0].ToString();
+                    sp2Box.Text = CourseData.GameTempos[1].ToString();
+                    sp3Box.Text = CourseData.GameTempos[2].ToString();
+                    sp4Box.Text = CourseData.GameTempos[3].ToString();
+                    songBox.SelectedIndex = CourseData.MusicID;
+                }
+
+            }
+            else
+            {
+                MessageBox.Show("CONFIG.OK64 Error! Continuing without loading previous user input.");
+            }
+        }
+
+        private void textureScrollSBox_TextChanged(object sender, EventArgs e)
+        {
+            int sScroll;
+            if (int.TryParse(textureScrollSBox.Text, out sScroll))
+            {
+                textureArray[textureBox.SelectedIndex].textureScrollS = sScroll;
+            }
+
+        }
+
+        private void textureScrollTBox_TextChanged(object sender, EventArgs e)
+        {
+            int tScroll;
+            if (int.TryParse(textureScrollTBox.Text, out tScroll))
+            {
+                textureArray[textureBox.SelectedIndex].textureScrollT = tScroll;
+            }
+        }
+
+        private void textBox7_TextChanged(object sender, EventArgs e)
+        {
+            int vAlpha;
+            if (int.TryParse(vertAlphaBox.Text, out vAlpha))
+            {
+                textureArray[textureBox.SelectedIndex].vertAlpha = vAlpha;
+            }
         }
     }
 }

--- a/tarmac/Tarmac64 Library/TM64.cs
+++ b/tarmac/Tarmac64 Library/TM64.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -92,6 +92,8 @@ namespace Tarmac64_Library
 
         public class OK64Settings
         {
+            public string AppDirectory { get; set; }
+            public string CurrentDirectory { get; set; }
             public string ProjectDirectory { get; set; }
             public string JRDirectory { get; set; }
             public bool Valid { get; set; }
@@ -361,6 +363,7 @@ namespace Tarmac64_Library
             string AppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string SettingsPath = Path.Combine(AppData, "Tarmac.OK64Settings");
             string[] settings = new string[0];
+            OkSettings.AppDirectory = Path.GetDirectoryName(Application.ExecutablePath);
 
             bool corrupt = Forced;
             if (!File.Exists(SettingsPath))
@@ -390,6 +393,7 @@ namespace Tarmac64_Library
                 CommonOpenFileDialog dialog = new CommonOpenFileDialog();
                 dialog.InitialDirectory = "C:\\";
                 dialog.IsFolderPicker = true;
+                dialog.Title = "Select Project Folder";
                 if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
                 {
                     OkSettings.ProjectDirectory = dialog.FileName;
@@ -397,6 +401,7 @@ namespace Tarmac64_Library
                 MessageBox.Show("Please select your TarmacJR Chunk Folder");
                 dialog.InitialDirectory = Path.GetDirectoryName(Application.ExecutablePath);
                 dialog.IsFolderPicker = true;
+                dialog.Title = "Select TarmacJR Chunk Folder";
                 if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
                 {
                     OkSettings.JRDirectory = dialog.FileName;

--- a/tarmac/Tarmac64 Library/TM64_Course.cs
+++ b/tarmac/Tarmac64 Library/TM64_Course.cs
@@ -1,4 +1,4 @@
-﻿using Assimp;
+using Assimp;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -972,6 +972,10 @@ namespace Tarmac64_Library
             Course CourseData = new Course();
 
             string[] inputFile = File.ReadAllLines(filePath);
+            if (inputFile.Length == 0) {
+                CourseData = null;
+                return CourseData;
+            }
             int thisLine = 0;
 
             CourseData.Credits = inputFile[thisLine];


### PR DESCRIPTION
Tarmac now only asks for the location of the FBX file. From there it infers the following:
1) overkart.z64 is placed beside the Tarmac executable
2) POP.OK64 file is beside the FBX file.
3) CONFIG.OK64 file is beside the FBX file.
4) out/ (the compiled binary folder) gets added beside the FBX file.

Texture loading remains unchanged and uninvestigated. It may or may not require the same treatment.

Renamed:
Ambiguous method name to ExportBtn_Click mirroring it's ImportBtn_Click counterpart.

Removed:
Import/Export buttons.

Added:
Auto saving/loading of CONFIG.OK64.
FBX file pick dialogue now uses WPF to implement filters so that the dialogue only displays .FBX files.
Two directories to `okSettings`:  
    `okSettings.CurrentDirectory` The FBX file location. "Working directory"
    `okSettings.AppDirectory` for loading overkart.z64

Notes:
May want to consider renaming overkart.z64 to Base4.X.z64. However, then you have to remember to update it every update. Perhaps overkart_4.1.z64 and use code to select any .z64 file with the name "overkart" but only the one with the highest value in the version number: `_X.x.` This way users can distinguish between overkart versions and tarmac always chooses the latest version if there's ever a mixup.

Why did I rename the OK64 files? OK64.CONFIG was taken by XML. So I decided to rename them both to .OK64 as that made more sense to me. Feel free to overwrite these changes (or any others) if you prefer a different way.
